### PR TITLE
Fix bug on panel creation with new awesome version

### DIFF
--- a/layout/left-panel/dashboard/hardware-monitor.lua
+++ b/layout/left-panel/dashboard/hardware-monitor.lua
@@ -35,7 +35,7 @@ return wibox.widget {
 			require('widget.cpu-meter'),
 			require('widget.ram-meter'),
 			require('widget.temperature-meter'),
-			require('widget.harddrive-meter')
+			table.pack(require('widget.harddrive-meter'))[1]
 		},
 		bg = beautiful.groups_bg,
 		shape = function(cr, width, height)

--- a/layout/left-panel/dashboard/init.lua
+++ b/layout/left-panel/dashboard/init.lua
@@ -67,7 +67,7 @@ return function(_, panel)
 				spacing = dpi(7),
 				search_button,
 				require('layout.left-panel.dashboard.hardware-monitor'),
-				require('layout.left-panel.dashboard.quick-settings'),
+				table.pack(require('layout.left-panel.dashboard.quick-settings'))[1],
 
 			},
 			nil,

--- a/layout/left-panel/dashboard/quick-settings.lua
+++ b/layout/left-panel/dashboard/quick-settings.lua
@@ -42,7 +42,7 @@ return wibox.widget {
 					require('widget.volume-slider'),
 					require('widget.airplane-mode'),
 					require('widget.bluetooth-toggle'),
-					require('widget.blue-light')
+					table.pack(require('widget.blue-light'))[1]
 				},
 				bg = beautiful.groups_bg,
 				shape = function(cr, width, height)

--- a/layout/right-panel/init.lua
+++ b/layout/right-panel/init.lua
@@ -142,7 +142,7 @@ local right_panel = function(s)
 						require('widget.weather'),
 						--require('widget.email'),
 						--require('widget.social-media'),
-						require('widget.calculator')
+						table.pack(require('widget.calculator'))[1]
 					},
 
 				},


### PR DESCRIPTION
Hi,

Because of a change in recent versions of lua, `require` now returns 2 values instead of 1.
This creates some issues with your config (#25).

I used the information on this [thread](https://github.com/awesomeWM/awesome/issues/3563) to fix this.
I tested it and it works fine (at least on my system) with the last version of the [awesome-git](https://aur.archlinux.org/packages/awesome-git) AUR package.